### PR TITLE
docs(readme): fix CLI command name 'models_to_tensor' -> 'model_to_tensor'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,12 +64,12 @@ In the following section, I highlighted cryoSBI key features.
 
 Generate model file to simulate cryo-EM particles
 -------------------------------------------------
-To generate a model file for simulating cryo-EM particles with the simulator provided in this module, you can use the command line tool `models_to_tensor`.
+To generate a model file for simulating cryo-EM particles with the simulator provided in this module, you can use the command line tool `model_to_tensor`.
 You will need either a set of pdbs which are indexd or a trr trejectory file which contians all models. The tool will generate a model file that can be used to simulate cryo-EM particles.
 
 .. code:: bash
 
-    models_to_tensor \
+    model_to_tensor \
         --model_file path_to_models/pdb_{}.pdb \
         --output_file path_to_output_file/output.pt \
         --n_pdbs 100


### PR DESCRIPTION
## Summary

\`pyproject.toml\` registers the installed console script as:

\`\`\`
model_to_tensor = \"cryo_sbi.utils.command_line_tools:cl_models_to_tensor\"
\`\`\`

so the shell command is \`model_to_tensor\` (singular). The README *Generate model file* section referred to \`models_to_tensor\` (plural) twice — in the paragraph text and in the bash snippet — which fails at the shell with 'command not found'.

Updated both occurrences to \`model_to_tensor\`.

The underlying Python function in \`generate_models.py\` remains \`models_to_tensor\`; only the CLI shell name differed.

Closes #69

## Testing

Docs-only change.